### PR TITLE
update to atom 0.6 and esp-idf 5+ support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,6 @@ idf_component_register(
 )
 
 idf_build_set_property(
-    LINK_OPTIONS "-Wl,--whole-archive ${CMAKE_CURRENT_BINARY_DIR}/lib${COMPONENT_NAME}.a -Wl,--no-whole-archive"
+    LINK_OPTIONS "-Wl,--whole-archive;${CMAKE_CURRENT_BINARY_DIR}/lib${COMPONENT_NAME}.a;-Wl,--no-whole-archive"
     APPEND
 )


### PR DESCRIPTION
minimal changes for functionality on atom 0.6 and esp-idf 5.x (5.1 in my case), I'm NOT a C programmer so do please quick review changes.

Tested on AI-thinker HW - works.

esp32-camera component installed using `idf.py add-dependency "espressif/esp32-camera"` in `src/platforms/esp32`, and enabling psram and some psram fiddling in `idf.py menuconfig`.