### PR TITLE
Add idf.component.yml for external dependencies

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,17 @@
+## IDF Component Manager Manifest File
+dependencies:
+  ## Required IDF version
+  idf:
+    version: '>=5.0.0'
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true
+  espressif/esp32-camera: '*'


### PR DESCRIPTION
Adds an idf.component.yml file to automatically retrieve the espressif/esp32-camera dependency.

Closes #3